### PR TITLE
Fix missing Uuid import in data proto

### DIFF
--- a/contracts/api/v1/data.proto
+++ b/contracts/api/v1/data.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package company.poc.ordering.api.v1;
 option csharp_namespace = "Company.Poc.Ordering.Api.V1";
 import "contracts/domain/v1/order.proto";
+import "contracts/domain/v1/common.proto";
 
 service Data {
   rpc SaveOrder(company.poc.ordering.domain.v1.PricedOrder) returns (company.poc.ordering.domain.v1.Uuid);


### PR DESCRIPTION
## Summary
- import `common.proto` into `data.proto` so `Uuid` is available

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0. Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0.)*

------
https://chatgpt.com/codex/tasks/task_e_68b297dc30b8832cbb05621a0662bdeb