### PR TITLE
Add gRPC Core API dependency to Contracts API project

### DIFF
--- a/src/BuildingBlocks/Contracts/Contracts.Api/Contracts.Api.csproj
+++ b/src/BuildingBlocks/Contracts/Contracts.Api/Contracts.Api.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.*" />
     <PackageReference Include="Grpc.Tools" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.*" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="../../../../contracts/api/v1/dispatcher.proto" ProtoRoot="../../../../" GrpcServices="Client,Server" />

--- a/src/Contracts/Contracts.Api/Contracts.Api.csproj
+++ b/src/Contracts/Contracts.Api/Contracts.Api.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.*" />
     <PackageReference Include="Grpc.Tools" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.*" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="../../../contracts/api/v1/dispatcher.proto" ProtoRoot="../../../" GrpcServices="Client,Server" />


### PR DESCRIPTION
## Summary
- include Grpc.Core.Api package in Contracts.Api projects to supply `Grpc` namespaces used by generated client/server code

## Testing
- `dotnet build poc-micro.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b299d045b8832ca9a0da1358d07958