### PR TITLE
Add gRPC Core API dependency to Contracts API project

### DIFF
--- a/contracts/api/v1/data.proto
+++ b/contracts/api/v1/data.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
-package company.poc.ordering.api.v1;
-option csharp_namespace = "Company.Poc.Ordering.Api.V1";
+package poc.micro.ordering.api.v1;
+option csharp_namespace = "Poc.Micro.Ordering.Api.V1";
 import "contracts/domain/v1/order.proto";
 import "contracts/domain/v1/common.proto";
 
 service Data {
-  rpc SaveOrder(company.poc.ordering.domain.v1.PricedOrder) returns (company.poc.ordering.domain.v1.Uuid);
+  rpc SaveOrder(poc.micro.ordering.domain.v1.PricedOrder) returns (poc.micro.ordering.domain.v1.Uuid);
 }

--- a/contracts/api/v1/dispatcher.proto
+++ b/contracts/api/v1/dispatcher.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package company.poc.ordering.api.v1;
-option csharp_namespace = "Company.Poc.Ordering.Api.V1";
+package poc.micro.ordering.api.v1;
+option csharp_namespace = "Poc.Micro.Ordering.Api.V1";
 import "contracts/domain/v1/order.proto";
 import "contracts/domain/v1/common.proto";
 
@@ -10,15 +10,15 @@ service Dispatcher {
 }
 
 message SubmitOrderRequest {
-  company.poc.ordering.domain.v1.Order order = 1;
+  poc.micro.ordering.domain.v1.Order order = 1;
   string client_id = 2; // meta solo di trasporto
 }
-message SubmitOrderResponse { company.poc.ordering.domain.v1.Uuid job_id = 1; }
+message SubmitOrderResponse { poc.micro.ordering.domain.v1.Uuid job_id = 1; }
 
-message GetStatusRequest { company.poc.ordering.domain.v1.Uuid job_id = 1; }
+message GetStatusRequest { poc.micro.ordering.domain.v1.Uuid job_id = 1; }
 enum JobState { JOB_STATE_PENDING=0; JOB_STATE_PRICED=1; JOB_STATE_RESERVED=2; JOB_STATE_PERSISTED=3; JOB_STATE_FAILED=4; }
 message JobStatus {
-  company.poc.ordering.domain.v1.Uuid job_id = 1;
+  poc.micro.ordering.domain.v1.Uuid job_id = 1;
   JobState state = 2;
   string message = 3;
 }

--- a/contracts/api/v1/inventory.proto
+++ b/contracts/api/v1/inventory.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
-package company.poc.ordering.api.v1;
-option csharp_namespace = "Company.Poc.Ordering.Api.V1";
+package poc.micro.ordering.api.v1;
+option csharp_namespace = "Poc.Micro.Ordering.Api.V1";
 import "contracts/domain/v1/order.proto";
 
 service Inventory {
-  rpc Reserve(company.poc.ordering.domain.v1.Order) returns (company.poc.ordering.domain.v1.ReservationResult);
+  rpc Reserve(poc.micro.ordering.domain.v1.Order) returns (poc.micro.ordering.domain.v1.ReservationResult);
 }

--- a/contracts/api/v1/logging.proto
+++ b/contracts/api/v1/logging.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package company.poc.ordering.api.v1;
-option csharp_namespace = "Company.Poc.Ordering.Api.V1";
+package poc.micro.ordering.api.v1;
+option csharp_namespace = "Poc.Micro.Ordering.Api.V1";
 
 service Logging {
   rpc Write(LogEntry) returns (WriteAck);

--- a/contracts/api/v1/pricing.proto
+++ b/contracts/api/v1/pricing.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
-package company.poc.ordering.api.v1;
-option csharp_namespace = "Company.Poc.Ordering.Api.V1";
+package poc.micro.ordering.api.v1;
+option csharp_namespace = "Poc.Micro.Ordering.Api.V1";
 import "contracts/domain/v1/order.proto";
 
 service Pricing {
-  rpc Calculate(company.poc.ordering.domain.v1.Order) returns (company.poc.ordering.domain.v1.PricedOrder);
+  rpc Calculate(poc.micro.ordering.domain.v1.Order) returns (poc.micro.ordering.domain.v1.PricedOrder);
 }

--- a/contracts/domain/v1/common.proto
+++ b/contracts/domain/v1/common.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package company.poc.ordering.domain.v1;
-option csharp_namespace = "Company.Poc.Ordering.Domain.V1";
+package poc.micro.ordering.domain.v1;
+option csharp_namespace = "Poc.Micro.Ordering.Domain.V1";
 
 message Uuid { string value = 1; }
 message Money { double amount = 1; string currency = 2; }

--- a/contracts/domain/v1/order.proto
+++ b/contracts/domain/v1/order.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package company.poc.ordering.domain.v1;
-option csharp_namespace = "Company.Poc.Ordering.Domain.V1";
+package poc.micro.ordering.domain.v1;
+option csharp_namespace = "Poc.Micro.Ordering.Domain.V1";
 import "contracts/domain/v1/common.proto";
 
 message OrderItem {

--- a/src/BuildingBlocks/Contracts/Contracts.Api/Contracts.Api.csproj
+++ b/src/BuildingBlocks/Contracts/Contracts.Api/Contracts.Api.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.*" />
     <PackageReference Include="Grpc.Tools" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.*" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="../../../../contracts/api/v1/dispatcher.proto" ProtoRoot="../../../../" GrpcServices="Client,Server" />

--- a/src/Contracts/Contracts.Api/Contracts.Api.csproj
+++ b/src/Contracts/Contracts.Api/Contracts.Api.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.*" />
     <PackageReference Include="Grpc.Tools" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.*" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="../../../contracts/api/v1/dispatcher.proto" ProtoRoot="../../../" GrpcServices="Client,Server" />


### PR DESCRIPTION
## Summary
- include Grpc.Core.Api package in Contracts.Api projects to supply `Grpc` namespaces used by generated client/server code
- switch gRPC contract package and C# namespaces from `Company.Poc` to `Poc.Micro` to align with `poc-micro.sln`

## Testing
- `dotnet build poc-micro.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b299d045b8832ca9a0da1358d07958