### PR TITLE
Implement dispatcher job orchestration and basic services

### DIFF
--- a/src/Services/Dispatcher/Dispatcher.Api/DispatcherWorker.cs
+++ b/src/Services/Dispatcher/Dispatcher.Api/DispatcherWorker.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Poc.Micro.Ordering.Api.V1;
+
+namespace Poc.Micro.Dispatcher.Api;
+
+public class DispatcherWorker : BackgroundService
+{
+    private readonly JobStore _jobs;
+    private readonly Pricing.PricingClient _pricing;
+    private readonly Inventory.InventoryClient _inventory;
+    private readonly Data.DataClient _data;
+    private readonly Logging.LoggingClient _log;
+
+    public DispatcherWorker(JobStore jobs, Pricing.PricingClient pricing, Inventory.InventoryClient inventory, Data.DataClient data, Logging.LoggingClient log)
+    {
+        _jobs = jobs;
+        _pricing = pricing;
+        _inventory = inventory;
+        _data = data;
+        _log = log;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var jobId in _jobs.DequeueAllAsync(stoppingToken))
+        {
+            try
+            {
+                _jobs.Upsert(new(jobId, JobState.Pending, "pricing"));
+                var order = _jobs.GetOrder(jobId) ?? throw new InvalidOperationException("Order not found");
+                var priced = await _pricing.CalculateAsync(order, cancellationToken: stoppingToken);
+
+                _jobs.Upsert(new(jobId, JobState.Priced, "inventory"));
+                var res = await _inventory.ReserveAsync(priced.Order, cancellationToken: stoppingToken);
+                if (!res.Reserved) throw new InvalidOperationException(res.Reason);
+
+                _jobs.Upsert(new(jobId, JobState.Reserved, "persisting"));
+                var saved = await _data.SaveOrderAsync(priced, cancellationToken: stoppingToken);
+                if (string.IsNullOrEmpty(saved.Value)) throw new InvalidOperationException("save failed");
+
+                _jobs.Upsert(new(jobId, JobState.Persisted, "done"));
+            }
+            catch (Exception ex)
+            {
+                _jobs.Upsert(new(jobId, JobState.Failed, ex.Message));
+                await _log.WriteAsync(new LogEntry
+                {
+                    Source = "dispatcher",
+                    Level = "ERROR",
+                    CorrelationId = jobId.ToString(),
+                    Message = ex.Message,
+                    UnixTsMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                }, cancellationToken: stoppingToken);
+            }
+        }
+    }
+}

--- a/src/Services/Dispatcher/Dispatcher.Api/JobStore.cs
+++ b/src/Services/Dispatcher/Dispatcher.Api/JobStore.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
+using Poc.Micro.Ordering.Api.V1;
+using Poc.Micro.Ordering.Domain.V1;
+
+namespace Poc.Micro.Dispatcher.Api;
+
+public record JobInfo(Guid JobId, JobState State, string Message);
+
+public class JobStore
+{
+    private readonly Channel<Guid> _queue = Channel.CreateUnbounded<Guid>();
+    private readonly ConcurrentDictionary<Guid, JobInfo> _kv = new();
+    private readonly ConcurrentDictionary<Guid, Order> _orders = new();
+
+    public ValueTask EnqueueAsync(Guid id) => _queue.Writer.WriteAsync(id);
+
+    public IAsyncEnumerable<Guid> DequeueAllAsync(CancellationToken ct) => _queue.Reader.ReadAllAsync(ct);
+
+    public void Upsert(JobInfo info) => _kv[info.JobId] = info;
+
+    public JobInfo? Get(Guid id) => _kv.TryGetValue(id, out var v) ? v : null;
+
+    public void SaveOrder(Guid id, Order order) => _orders[id] = order;
+
+    public Order? GetOrder(Guid id) => _orders.TryGetValue(id, out var v) ? v : null;
+}

--- a/src/Services/Dispatcher/Dispatcher.Api/Program.cs
+++ b/src/Services/Dispatcher/Dispatcher.Api/Program.cs
@@ -1,15 +1,28 @@
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Http;
 using Poc.Micro.Dispatcher.Api;
+using Poc.Micro.Ordering.Api.V1;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddGrpc();
+builder.Services.AddHealthChecks();
+builder.Services.AddSingleton<JobStore>();
+builder.Services.AddHostedService<DispatcherWorker>();
+
+builder.Services.AddGrpcClient<Pricing.PricingClient>(o => o.Address = new Uri(GetEnv("PRICING_URL")));
+builder.Services.AddGrpcClient<Inventory.InventoryClient>(o => o.Address = new Uri(GetEnv("INVENTORY_URL")));
+builder.Services.AddGrpcClient<Data.DataClient>(o => o.Address = new Uri(GetEnv("DATA_URL")));
+builder.Services.AddGrpcClient<Logging.LoggingClient>(o => o.Address = new Uri(GetEnv("LOG_URL")));
 
 var app = builder.Build();
 
 app.MapGrpcService<DispatcherService>();
-app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client.");
+app.MapGet("/healthz", () => Results.Ok("ok"));
 
 app.Run();
+
+static string GetEnv(string k) => Environment.GetEnvironmentVariable(k) ?? throw new InvalidOperationException($"Missing {k}");

--- a/src/Services/Inventory/Inventory.Api/InventoryService.cs
+++ b/src/Services/Inventory/Inventory.Api/InventoryService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Poc.Micro.Ordering.Api.V1;
@@ -9,13 +10,29 @@ using ApiInventory = Poc.Micro.Ordering.Api.V1.Inventory;
 
 public class InventoryService : ApiInventory.InventoryBase
 {
+    private readonly ConcurrentDictionary<string, int> _stock = new();
+
     public override Task<ReservationResult> Reserve(Order request, ServerCallContext context)
     {
-        return Task.FromResult(new ReservationResult
+        foreach (var item in request.Items)
         {
-            Order = request,
-            Reserved = true,
-            Reason = string.Empty
-        });
+            var available = _stock.GetOrAdd(item.Sku, 100);
+            if (available < item.Qty.Value)
+            {
+                return Task.FromResult(new ReservationResult
+                {
+                    Order = request,
+                    Reserved = false,
+                    Reason = $"insufficient stock for {item.Sku}"
+                });
+            }
+        }
+
+        foreach (var item in request.Items)
+        {
+            _stock.AddOrUpdate(item.Sku, _ => 100 - item.Qty.Value, (_, current) => current - item.Qty.Value);
+        }
+
+        return Task.FromResult(new ReservationResult { Order = request, Reserved = true, Reason = string.Empty });
     }
 }

--- a/src/Services/Pricing/Pricing.Api/PricingService.cs
+++ b/src/Services/Pricing/Pricing.Api/PricingService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Poc.Micro.Ordering.Api.V1;
@@ -14,23 +16,24 @@ public class PricingService : ApiPricing.PricingBase
         double subtotal = 0;
         foreach (var item in request.Items)
         {
-            if (item.UnitPrice == null)
+            if (item.UnitPrice == null || item.UnitPrice.Amount <= 0)
             {
-                item.UnitPrice = new Money { Amount = 10, Currency = "USD" };
+                item.UnitPrice = new Money { Amount = MockPrice(item.Sku), Currency = "EUR" };
             }
             subtotal += item.UnitPrice.Amount * item.Qty.Value;
         }
 
-        var subtotalMoney = new Money { Amount = subtotal, Currency = "USD" };
-        var taxMoney = new Money { Amount = subtotal * 0.2, Currency = "USD" };
-        var totalMoney = new Money { Amount = subtotalMoney.Amount + taxMoney.Amount, Currency = "USD" };
+        var tax = Math.Round(subtotal * 0.22, 2);
+        var total = subtotal + tax;
 
         return Task.FromResult(new PricedOrder
         {
             Order = request,
-            Subtotal = subtotalMoney,
-            Tax = taxMoney,
-            Total = totalMoney
+            Subtotal = new Money { Amount = subtotal, Currency = "EUR" },
+            Tax = new Money { Amount = tax, Currency = "EUR" },
+            Total = new Money { Amount = total, Currency = "EUR" }
         });
     }
+
+    private static double MockPrice(string sku) => sku.GetHashCode() % 10 + 10;
 }


### PR DESCRIPTION
## Summary
- add JobStore and DispatcherWorker to orchestrate pricing, inventory and persistence calls
- queue and track jobs in DispatcherService with logging and status streaming
- implement simple pricing and inventory business logic

## Testing
- `dotnet build src/Services/Pricing/Pricing.Api/Pricing.Api.csproj`
- `dotnet build src/Services/Inventory/Inventory.Api/Inventory.Api.csproj`
- `dotnet build src/Services/Dispatcher/Dispatcher.Api/Dispatcher.Api.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b2c2d5e4a8832cb3fc5332b37435b2