### PR TITLE
Add Dockerfiles and compose setup for microservices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '3.9'
+services:
+  data:
+    build:
+      context: .
+      dockerfile: src/Services/Data/Data.Api/Dockerfile
+    container_name: data
+    ports:
+      - "5001:8080"
+    volumes:
+      - data:/data
+  inventory:
+    build:
+      context: .
+      dockerfile: src/Services/Inventory/Inventory.Api/Dockerfile
+    container_name: inventory
+    ports:
+      - "5002:8080"
+  pricing:
+    build:
+      context: .
+      dockerfile: src/Services/Pricing/Pricing.Api/Dockerfile
+    container_name: pricing
+    ports:
+      - "5003:8080"
+  logger:
+    build:
+      context: .
+      dockerfile: src/Services/Logger/Logger.Api/Dockerfile
+    container_name: logger
+    ports:
+      - "5004:8080"
+    volumes:
+      - logs:/logs
+  dispatcher:
+    build:
+      context: .
+      dockerfile: src/Services/Dispatcher/Dispatcher.Api/Dockerfile
+    container_name: dispatcher
+    depends_on:
+      - data
+      - inventory
+      - pricing
+      - logger
+    environment:
+      PRICING_URL: http://pricing:8080
+      INVENTORY_URL: http://inventory:8080
+      DATA_URL: http://data:8080
+      LOG_URL: http://logger:8080
+    ports:
+      - "5000:8080"
+volumes:
+  data:
+  logs:

--- a/src/Services/Data/Data.Api/Dockerfile
+++ b/src/Services/Data/Data.Api/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+WORKDIR /src/Services/Data/Data.Api
+RUN dotnet publish Data.Api.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Data.Api.dll"]

--- a/src/Services/Dispatcher/Dispatcher.Api/Dockerfile
+++ b/src/Services/Dispatcher/Dispatcher.Api/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+WORKDIR /src/Services/Dispatcher/Dispatcher.Api
+RUN dotnet publish Dispatcher.Api.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Dispatcher.Api.dll"]

--- a/src/Services/Inventory/Inventory.Api/Dockerfile
+++ b/src/Services/Inventory/Inventory.Api/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+WORKDIR /src/Services/Inventory/Inventory.Api
+RUN dotnet publish Inventory.Api.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Inventory.Api.dll"]

--- a/src/Services/Logger/Logger.Api/Dockerfile
+++ b/src/Services/Logger/Logger.Api/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+WORKDIR /src/Services/Logger/Logger.Api
+RUN dotnet publish Logger.Api.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Logger.Api.dll"]

--- a/src/Services/Pricing/Pricing.Api/Dockerfile
+++ b/src/Services/Pricing/Pricing.Api/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+WORKDIR /src/Services/Pricing/Pricing.Api
+RUN dotnet publish Pricing.Api.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Pricing.Api.dll"]


### PR DESCRIPTION
## Summary
- add Dockerfiles for Data, Dispatcher, Inventory, Logger and Pricing services
- add docker-compose to run microservice stack with volumes and cross-service URLs

## Testing
- `dotnet test`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cdd404b0832c9e96b21aa20c2c03