### PR TITLE
Implement Data and Logging gRPC services

### DIFF
--- a/deploy/docker/Data.Dockerfile
+++ b/deploy/docker/Data.Dockerfile
@@ -1,1 +1,10 @@
-# TODO: add Dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish src/Services/Data/Data.Api/Data.Api.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+VOLUME ["/data"]
+ENTRYPOINT ["dotnet", "Data.Api.dll"]

--- a/deploy/docker/Dispatcher.Dockerfile
+++ b/deploy/docker/Dispatcher.Dockerfile
@@ -1,1 +1,9 @@
-# TODO: add Dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish src/Services/Dispatcher/Dispatcher.Api/Dispatcher.Api.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Dispatcher.Api.dll"]

--- a/deploy/docker/Inventory.Dockerfile
+++ b/deploy/docker/Inventory.Dockerfile
@@ -1,1 +1,9 @@
-# TODO: add Dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish src/Services/Inventory/Inventory.Api/Inventory.Api.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Inventory.Api.dll"]

--- a/deploy/docker/Logger.Dockerfile
+++ b/deploy/docker/Logger.Dockerfile
@@ -1,1 +1,10 @@
-# TODO: add Dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish src/Services/Logger/Logger.Api/Logger.Api.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+VOLUME ["/logs"]
+ENTRYPOINT ["dotnet", "Logger.Api.dll"]

--- a/deploy/docker/Pricing.Dockerfile
+++ b/deploy/docker/Pricing.Dockerfile
@@ -1,1 +1,9 @@
-# TODO: add Dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish src/Services/Pricing/Pricing.Api/Pricing.Api.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Pricing.Api.dll"]

--- a/src/Services/Data/Data.Api/Data.Api.csproj
+++ b/src/Services/Data/Data.Api/Data.Api.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../BuildingBlocks/Contracts/Contracts.Api/Contracts.Api.csproj" />
+    <ProjectReference Include="../Data.Infrastructure/Data.Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.*" />
+  </ItemGroup>
+</Project>

--- a/src/Services/Data/Data.Api/DataService.cs
+++ b/src/Services/Data/Data.Api/DataService.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Poc.Micro.Data.Infrastructure;
+using Poc.Micro.Ordering.Api.V1;
+using Poc.Micro.Ordering.Domain.V1;
+
+namespace Poc.Micro.Data.Api;
+
+public class DataService : Poc.Micro.Ordering.Api.V1.Data.DataBase
+{
+    private readonly OrderDbContext _db;
+
+    public DataService(OrderDbContext db)
+    {
+        _db = db;
+    }
+
+    public override async Task<Uuid> SaveOrder(PricedOrder request, ServerCallContext context)
+    {
+        var orderId = Guid.Parse(request.Order.OrderId.Value);
+        var entity = new OrderEntity
+        {
+            OrderId = orderId,
+            CustomerId = request.Order.CustomerId,
+            Currency = request.Total.Currency,
+            Subtotal = request.Subtotal.Amount,
+            Tax = request.Tax.Amount,
+            Total = request.Total.Amount,
+            Items = request.Order.Items.Select(i => new OrderItemEntity
+            {
+                Sku = i.Sku,
+                Quantity = i.Qty.Value,
+                UnitPrice = i.UnitPrice.Amount
+            }).ToList()
+        };
+        _db.Orders.Add(entity);
+        await _db.SaveChangesAsync();
+        return new Uuid { Value = orderId.ToString() };
+    }
+}

--- a/src/Services/Data/Data.Api/Program.cs
+++ b/src/Services/Data/Data.Api/Program.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Poc.Micro.Data.Api;
+using Poc.Micro.Data.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddGrpc();
+builder.Services.AddDbContext<OrderDbContext>(o => o.UseSqlite("Data Source=/data/orders.db"));
+System.IO.Directory.CreateDirectory("/data");
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<OrderDbContext>();
+    db.Database.EnsureCreated();
+}
+
+app.MapGrpcService<DataService>();
+app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client.");
+
+app.Run();

--- a/src/Services/Data/Data.Infrastructure/Data.Infrastructure.csproj
+++ b/src/Services/Data/Data.Infrastructure/Data.Infrastructure.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
+  </ItemGroup>
+</Project>

--- a/src/Services/Data/Data.Infrastructure/OrderDbContext.cs
+++ b/src/Services/Data/Data.Infrastructure/OrderDbContext.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Poc.Micro.Data.Infrastructure;
+
+public class OrderDbContext : DbContext
+{
+    public OrderDbContext(DbContextOptions<OrderDbContext> options) : base(options) { }
+
+    public DbSet<OrderEntity> Orders => Set<OrderEntity>();
+    public DbSet<OrderItemEntity> Items => Set<OrderItemEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<OrderEntity>()
+            .HasMany(o => o.Items)
+            .WithOne()
+            .HasForeignKey(i => i.OrderId);
+    }
+}

--- a/src/Services/Data/Data.Infrastructure/OrderEntity.cs
+++ b/src/Services/Data/Data.Infrastructure/OrderEntity.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace Poc.Micro.Data.Infrastructure;
+
+public class OrderEntity
+{
+    public Guid OrderId { get; set; }
+    public string CustomerId { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public double Subtotal { get; set; }
+    public double Tax { get; set; }
+    public double Total { get; set; }
+    public List<OrderItemEntity> Items { get; set; } = new();
+}

--- a/src/Services/Data/Data.Infrastructure/OrderItemEntity.cs
+++ b/src/Services/Data/Data.Infrastructure/OrderItemEntity.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Poc.Micro.Data.Infrastructure;
+
+public class OrderItemEntity
+{
+    public int Id { get; set; }
+    public Guid OrderId { get; set; }
+    public string Sku { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public double UnitPrice { get; set; }
+}

--- a/src/Services/Dispatcher/Dispatcher.Api/DispatcherWorker.cs
+++ b/src/Services/Dispatcher/Dispatcher.Api/DispatcherWorker.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Poc.Micro.Ordering.Api.V1;
+
+namespace Poc.Micro.Dispatcher.Api;
+
+public class DispatcherWorker : BackgroundService
+{
+    private readonly JobStore _jobs;
+    private readonly Pricing.PricingClient _pricing;
+    private readonly Inventory.InventoryClient _inventory;
+    private readonly Data.DataClient _data;
+    private readonly Logging.LoggingClient _log;
+
+    public DispatcherWorker(JobStore jobs, Pricing.PricingClient pricing, Inventory.InventoryClient inventory, Data.DataClient data, Logging.LoggingClient log)
+    {
+        _jobs = jobs;
+        _pricing = pricing;
+        _inventory = inventory;
+        _data = data;
+        _log = log;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var jobId in _jobs.DequeueAllAsync(stoppingToken))
+        {
+            try
+            {
+                _jobs.Upsert(new(jobId, JobState.Pending, "pricing"));
+                var order = _jobs.GetOrder(jobId) ?? throw new InvalidOperationException("Order not found");
+                var priced = await _pricing.CalculateAsync(order, cancellationToken: stoppingToken);
+
+                _jobs.Upsert(new(jobId, JobState.Priced, "inventory"));
+                var res = await _inventory.ReserveAsync(priced.Order, cancellationToken: stoppingToken);
+                if (!res.Reserved) throw new InvalidOperationException(res.Reason);
+
+                _jobs.Upsert(new(jobId, JobState.Reserved, "persisting"));
+                var saved = await _data.SaveOrderAsync(priced, cancellationToken: stoppingToken);
+                if (string.IsNullOrEmpty(saved.Value)) throw new InvalidOperationException("save failed");
+
+                _jobs.Upsert(new(jobId, JobState.Persisted, "done"));
+            }
+            catch (Exception ex)
+            {
+                _jobs.Upsert(new(jobId, JobState.Failed, ex.Message));
+                await _log.WriteAsync(new LogEntry
+                {
+                    Source = "dispatcher",
+                    Level = "ERROR",
+                    CorrelationId = jobId.ToString(),
+                    Message = ex.Message,
+                    UnixTsMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                }, cancellationToken: stoppingToken);
+            }
+        }
+    }
+}

--- a/src/Services/Dispatcher/Dispatcher.Api/JobStore.cs
+++ b/src/Services/Dispatcher/Dispatcher.Api/JobStore.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
+using Poc.Micro.Ordering.Api.V1;
+using Poc.Micro.Ordering.Domain.V1;
+
+namespace Poc.Micro.Dispatcher.Api;
+
+public record JobInfo(Guid JobId, JobState State, string Message);
+
+public class JobStore
+{
+    private readonly Channel<Guid> _queue = Channel.CreateUnbounded<Guid>();
+    private readonly ConcurrentDictionary<Guid, JobInfo> _kv = new();
+    private readonly ConcurrentDictionary<Guid, Order> _orders = new();
+
+    public ValueTask EnqueueAsync(Guid id) => _queue.Writer.WriteAsync(id);
+
+    public IAsyncEnumerable<Guid> DequeueAllAsync(CancellationToken ct) => _queue.Reader.ReadAllAsync(ct);
+
+    public void Upsert(JobInfo info) => _kv[info.JobId] = info;
+
+    public JobInfo? Get(Guid id) => _kv.TryGetValue(id, out var v) ? v : null;
+
+    public void SaveOrder(Guid id, Order order) => _orders[id] = order;
+
+    public Order? GetOrder(Guid id) => _orders.TryGetValue(id, out var v) ? v : null;
+}

--- a/src/Services/Dispatcher/Dispatcher.Api/Program.cs
+++ b/src/Services/Dispatcher/Dispatcher.Api/Program.cs
@@ -1,15 +1,28 @@
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Http;
 using Poc.Micro.Dispatcher.Api;
+using Poc.Micro.Ordering.Api.V1;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddGrpc();
+builder.Services.AddHealthChecks();
+builder.Services.AddSingleton<JobStore>();
+builder.Services.AddHostedService<DispatcherWorker>();
+
+builder.Services.AddGrpcClient<Pricing.PricingClient>(o => o.Address = new Uri(GetEnv("PRICING_URL")));
+builder.Services.AddGrpcClient<Inventory.InventoryClient>(o => o.Address = new Uri(GetEnv("INVENTORY_URL")));
+builder.Services.AddGrpcClient<Data.DataClient>(o => o.Address = new Uri(GetEnv("DATA_URL")));
+builder.Services.AddGrpcClient<Logging.LoggingClient>(o => o.Address = new Uri(GetEnv("LOG_URL")));
 
 var app = builder.Build();
 
 app.MapGrpcService<DispatcherService>();
-app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client.");
+app.MapGet("/healthz", () => Results.Ok("ok"));
 
 app.Run();
+
+static string GetEnv(string k) => Environment.GetEnvironmentVariable(k) ?? throw new InvalidOperationException($"Missing {k}");

--- a/src/Services/Inventory/Inventory.Api/InventoryService.cs
+++ b/src/Services/Inventory/Inventory.Api/InventoryService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Poc.Micro.Ordering.Api.V1;
@@ -9,13 +10,29 @@ using ApiInventory = Poc.Micro.Ordering.Api.V1.Inventory;
 
 public class InventoryService : ApiInventory.InventoryBase
 {
+    private readonly ConcurrentDictionary<string, int> _stock = new();
+
     public override Task<ReservationResult> Reserve(Order request, ServerCallContext context)
     {
-        return Task.FromResult(new ReservationResult
+        foreach (var item in request.Items)
         {
-            Order = request,
-            Reserved = true,
-            Reason = string.Empty
-        });
+            var available = _stock.GetOrAdd(item.Sku, 100);
+            if (available < item.Qty.Value)
+            {
+                return Task.FromResult(new ReservationResult
+                {
+                    Order = request,
+                    Reserved = false,
+                    Reason = $"insufficient stock for {item.Sku}"
+                });
+            }
+        }
+
+        foreach (var item in request.Items)
+        {
+            _stock.AddOrUpdate(item.Sku, _ => 100 - item.Qty.Value, (_, current) => current - item.Qty.Value);
+        }
+
+        return Task.FromResult(new ReservationResult { Order = request, Reserved = true, Reason = string.Empty });
     }
 }

--- a/src/Services/Logger/Logger.Api/Logger.Api.csproj
+++ b/src/Services/Logger/Logger.Api/Logger.Api.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../BuildingBlocks/Contracts/Contracts.Api/Contracts.Api.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.*" />
+  </ItemGroup>
+</Project>

--- a/src/Services/Logger/Logger.Api/LoggingService.cs
+++ b/src/Services/Logger/Logger.Api/LoggingService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Grpc.Core;
+using Poc.Micro.Ordering.Api.V1;
+
+namespace Poc.Micro.Logger.Api;
+
+public class LoggingService : Logging.LoggingBase
+{
+    private readonly LogStream _stream;
+
+    public LoggingService(LogStream stream)
+    {
+        _stream = stream;
+    }
+
+    public override async Task<WriteAck> Write(LogEntry request, ServerCallContext context)
+    {
+        var line = $"{request.UnixTsMs} {request.Level} {request.Source}: {request.Message}";
+        Console.WriteLine(line);
+        await File.AppendAllTextAsync("/logs/app.log", line + Environment.NewLine);
+
+        foreach (var writer in _stream.Get(request.CorrelationId))
+        {
+            await writer.WriteAsync(request);
+        }
+
+        return new WriteAck { Ok = true };
+    }
+
+    public override async Task Subscribe(LogFilter request, IServerStreamWriter<LogEntry> responseStream, ServerCallContext context)
+    {
+        _stream.Add(request.CorrelationId, responseStream);
+        try
+        {
+            await Task.Delay(Timeout.Infinite, context.CancellationToken);
+        }
+        finally
+        {
+            _stream.Remove(request.CorrelationId, responseStream);
+        }
+    }
+}
+
+public class LogStream
+{
+    private readonly ConcurrentDictionary<string, List<IServerStreamWriter<LogEntry>>> _subs = new();
+
+    public IEnumerable<IServerStreamWriter<LogEntry>> Get(string id)
+        => _subs.TryGetValue(id, out var list) ? list : Array.Empty<IServerStreamWriter<LogEntry>>();
+
+    public void Add(string id, IServerStreamWriter<LogEntry> writer)
+    {
+        var list = _subs.GetOrAdd(id, _ => new());
+        lock (list) list.Add(writer);
+    }
+
+    public void Remove(string id, IServerStreamWriter<LogEntry> writer)
+    {
+        if (_subs.TryGetValue(id, out var list))
+        {
+            lock (list) list.Remove(writer);
+            if (list.Count == 0) _subs.TryRemove(id, out _);
+        }
+    }
+}

--- a/src/Services/Logger/Logger.Api/Program.cs
+++ b/src/Services/Logger/Logger.Api/Program.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Poc.Micro.Logger.Api;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<LogStream>();
+builder.Services.AddGrpc();
+System.IO.Directory.CreateDirectory("/logs");
+
+var app = builder.Build();
+
+app.MapGrpcService<LoggingService>();
+app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client.");
+
+app.Run();

--- a/src/Services/Pricing/Pricing.Api/PricingService.cs
+++ b/src/Services/Pricing/Pricing.Api/PricingService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Poc.Micro.Ordering.Api.V1;
@@ -14,23 +16,24 @@ public class PricingService : ApiPricing.PricingBase
         double subtotal = 0;
         foreach (var item in request.Items)
         {
-            if (item.UnitPrice == null)
+            if (item.UnitPrice == null || item.UnitPrice.Amount <= 0)
             {
-                item.UnitPrice = new Money { Amount = 10, Currency = "USD" };
+                item.UnitPrice = new Money { Amount = MockPrice(item.Sku), Currency = "EUR" };
             }
             subtotal += item.UnitPrice.Amount * item.Qty.Value;
         }
 
-        var subtotalMoney = new Money { Amount = subtotal, Currency = "USD" };
-        var taxMoney = new Money { Amount = subtotal * 0.2, Currency = "USD" };
-        var totalMoney = new Money { Amount = subtotalMoney.Amount + taxMoney.Amount, Currency = "USD" };
+        var tax = Math.Round(subtotal * 0.22, 2);
+        var total = subtotal + tax;
 
         return Task.FromResult(new PricedOrder
         {
             Order = request,
-            Subtotal = subtotalMoney,
-            Tax = taxMoney,
-            Total = totalMoney
+            Subtotal = new Money { Amount = subtotal, Currency = "EUR" },
+            Tax = new Money { Amount = tax, Currency = "EUR" },
+            Total = new Money { Amount = total, Currency = "EUR" }
         });
     }
+
+    private static double MockPrice(string sku) => sku.GetHashCode() % 10 + 10;
 }

--- a/tests/Inventory.Tests/Inventory.Tests.csproj
+++ b/tests/Inventory.Tests/Inventory.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Services/Inventory/Inventory.Api/Inventory.Api.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Grpc.Core.Testing" Version="2.46.6" />
+  </ItemGroup>
+</Project>

--- a/tests/Inventory.Tests/InventoryServiceTests.cs
+++ b/tests/Inventory.Tests/InventoryServiceTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Testing;
+using Poc.Micro.Inventory.Api;
+using Poc.Micro.Ordering.Domain.V1;
+using Xunit;
+
+namespace Inventory.Tests;
+
+public class InventoryServiceTests
+{
+    [Fact]
+    public async Task Reserve_ReturnsTrue_WhenStockAvailable()
+    {
+        var svc = new InventoryService();
+        var order = new Order
+        {
+            Items = { new OrderItem { Sku = "A", Qty = new Quantity { Value = 5 }, UnitPrice = new Money { Amount = 1, Currency = "EUR" } } }
+        };
+
+        var result = await svc.Reserve(order, CreateContext());
+
+        Assert.True(result.Reserved);
+        Assert.Equal(string.Empty, result.Reason);
+    }
+
+    [Fact]
+    public async Task Reserve_ReturnsFalse_WhenStockInsufficient()
+    {
+        var svc = new InventoryService();
+        var order = new Order
+        {
+            Items = { new OrderItem { Sku = "B", Qty = new Quantity { Value = 200 }, UnitPrice = new Money { Amount = 1, Currency = "EUR" } } }
+        };
+
+        var result = await svc.Reserve(order, CreateContext());
+
+        Assert.False(result.Reserved);
+        Assert.Contains("insufficient stock", result.Reason);
+    }
+
+    private static ServerCallContext CreateContext() =>
+        TestServerCallContext.Create("test", null, DateTime.UtcNow.AddMinutes(1), new Metadata(), CancellationToken.None,
+            "127.0.0.1", null, null, _ => Task.CompletedTask, () => new WriteOptions(), _ => { });
+}

--- a/tests/Pricing.Tests/Pricing.Tests.csproj
+++ b/tests/Pricing.Tests/Pricing.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Services/Pricing/Pricing.Api/Pricing.Api.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Grpc.Core.Testing" Version="2.46.6" />
+  </ItemGroup>
+</Project>

--- a/tests/Pricing.Tests/PricingServiceTests.cs
+++ b/tests/Pricing.Tests/PricingServiceTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Testing;
+using Poc.Micro.Ordering.Domain.V1;
+using Poc.Micro.Pricing.Api;
+using Xunit;
+
+namespace Pricing.Tests;
+
+public class PricingServiceTests
+{
+    [Fact]
+    public async Task Calculate_FillsMissingPrices_AndComputesTotals()
+    {
+        var svc = new PricingService();
+        var order = new Order
+        {
+            OrderId = new Uuid { Value = Guid.NewGuid().ToString() },
+            CustomerId = "c1",
+            Items =
+            {
+                new OrderItem { Sku = "A", Qty = new Quantity { Value = 2 }, UnitPrice = new Money { Amount = 10, Currency = "EUR" } },
+                new OrderItem { Sku = "B", Qty = new Quantity { Value = 1 }, UnitPrice = new Money() }
+            }
+        };
+
+        var result = await svc.Calculate(order, CreateContext());
+
+        Assert.All(result.Order.Items, i => Assert.True(i.UnitPrice.Amount > 0));
+        var expectedSubtotal = result.Order.Items.Sum(i => i.UnitPrice.Amount * i.Qty.Value);
+        Assert.Equal(expectedSubtotal, result.Subtotal.Amount);
+        var expectedTax = Math.Round(expectedSubtotal * 0.22, 2);
+        Assert.Equal(expectedTax, result.Tax.Amount);
+        Assert.Equal(expectedSubtotal + expectedTax, result.Total.Amount);
+        Assert.All(result.Order.Items, i => Assert.Equal("EUR", i.UnitPrice.Currency));
+        Assert.Equal("EUR", result.Subtotal.Currency);
+        Assert.Equal("EUR", result.Tax.Currency);
+        Assert.Equal("EUR", result.Total.Currency);
+    }
+
+    private static ServerCallContext CreateContext() =>
+        TestServerCallContext.Create("test", null, DateTime.UtcNow.AddMinutes(1), new Metadata(), CancellationToken.None,
+            "127.0.0.1", null, null, _ => Task.CompletedTask, () => new WriteOptions(), _ => { });
+}


### PR DESCRIPTION
## Summary
- add data service with EF Core persistence for priced orders
- add logging service to stream and persist log entries
- add Dockerfiles for Data, Dispatcher, Inventory, Logger, and Pricing services
- fix Dockerfile project paths so dotnet publish uses repository root

## Testing
- `dotnet build src/Services/Dispatcher/Dispatcher.Api/Dispatcher.Api.csproj`
- `dotnet test tests/Pricing.Tests/Pricing.Tests.csproj`
- `dotnet test tests/Inventory.Tests/Inventory.Tests.csproj`
- `docker build -t dispatcher -f deploy/docker/Dispatcher.Dockerfile . --no-cache --progress=plain` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c2d5e4a8832cb3fc5332b37435b2