### PR TITLE
fix: correct paths in service Dockerfiles

### DIFF
--- a/deploy/docker/Data.Dockerfile
+++ b/deploy/docker/Data.Dockerfile
@@ -2,7 +2,9 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY . .
 
-RUN dotnet publish /src/Services/Data/Data.Api/Data.Api.csproj -c Release -o /app/publish
+# The source code resides under the top-level `src` directory.
+# After copying the repository into `/src`, adjust the project path accordingly.
+RUN dotnet publish src/Services/Data/Data.Api/Data.Api.csproj -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app

--- a/deploy/docker/Dispatcher.Dockerfile
+++ b/deploy/docker/Dispatcher.Dockerfile
@@ -2,7 +2,8 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY . .
 
-RUN dotnet publish /src/Services/Dispatcher/Dispatcher.Api/Dispatcher.Api.csproj -c Release -o /app/publish
+# Handle the nested `src` directory structure.
+RUN dotnet publish src/Services/Dispatcher/Dispatcher.Api/Dispatcher.Api.csproj -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app

--- a/deploy/docker/Inventory.Dockerfile
+++ b/deploy/docker/Inventory.Dockerfile
@@ -2,7 +2,8 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY . .
 
-RUN dotnet publish /src/Services/Inventory/Inventory.Api/Inventory.Api.csproj -c Release -o /app/publish
+# Account for the repository's nested `src` directory when publishing.
+RUN dotnet publish src/Services/Inventory/Inventory.Api/Inventory.Api.csproj -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app

--- a/deploy/docker/Logger.Dockerfile
+++ b/deploy/docker/Logger.Dockerfile
@@ -2,7 +2,10 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY . .
 
-RUN dotnet publish /src/Services/Logger/Logger.Api/Logger.Api.csproj -c Release -o /app/publish
+# The repository structure nests application code under a top-level `src` directory.
+# After copying the repository into `/src`, project files live at `/src/src/...`.
+# Adjust the publish path accordingly so `dotnet` can locate the project file.
+RUN dotnet publish src/Services/Logger/Logger.Api/Logger.Api.csproj -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app

--- a/deploy/docker/Pricing.Dockerfile
+++ b/deploy/docker/Pricing.Dockerfile
@@ -2,7 +2,8 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY . .
 
-RUN dotnet publish /src/Services/Pricing/Pricing.Api/Pricing.Api.csproj -c Release -o /app/publish
+# Adjust for nested repository layout (`/src/src/...`).
+RUN dotnet publish src/Services/Pricing/Pricing.Api/Pricing.Api.csproj -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app


### PR DESCRIPTION
## Summary
- fix incorrect project paths in service Dockerfiles to account for nested src directory

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b30e06aa54832ca664de3dcb1737ca