### PR TITLE
feat: update grpc-web proxy image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # poc-microservice
 
 This repository contains a proof-of-concept microservice system. The solution file is `poc-micro.sln` and the source code follows the structured layout under `src`, `tests`, `deploy`, `scripts`, `config`, and versioned protobuf contracts in `contracts`.
+
+## Docker Compose
+
+The provided `docker-compose.yml` includes a [gRPC-Web proxy](https://github.com/grpc/grpc-web)
+based on the `quay.io/grpcweb/grpcwebproxy:v0.15.0` image. The proxy forwards gRPC-Web
+requests to the `dispatcher` service and is configured with:
+
+```
+command:
+  - --backend_addr=dispatcher:8080
+  - --run_tls_server=false
+  - --allow_all_origins
+```
+
+This replaces the previous `improbable/grpc-web` image and environment variables.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,17 @@ services:
       LOG_URL: http://logger:8080
     ports:
       - "5000:8080"
+  grpcweb:
+    image: quay.io/grpcweb/grpcwebproxy:v0.15.0
+    container_name: grpcweb
+    depends_on:
+      - dispatcher
+    command:
+      - --backend_addr=dispatcher:8080
+      - --run_tls_server=false
+      - --allow_all_origins
+    ports:
+      - "5005:8080"
 volumes:
   data:
   logs:


### PR DESCRIPTION
## Summary
- add grpcwebproxy container to docker-compose
- document new grpc-web proxy image and options

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: unable to locate package)*
- `bash /tmp/dotnet-install.sh --version 9.0.0` *(fails: could not find .NET Core SDK 9.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b32089b814832cbbeb0cf5a33e5756