### PR TITLE
Fix frontend protobuf import paths to avoid 404 errors

### DIFF
--- a/frontend/public/contracts/api/v1/dispatcher.proto
+++ b/frontend/public/contracts/api/v1/dispatcher.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 package poc.micro.ordering.api.v1;
 option csharp_namespace = "Poc.Micro.Ordering.Api.V1";
-import "contracts/domain/v1/order.proto";
-import "contracts/domain/v1/common.proto";
+import "../domain/v1/order.proto";
+import "../domain/v1/common.proto";
 
 service Dispatcher {
   rpc SubmitOrder(SubmitOrderRequest) returns (SubmitOrderResponse);

--- a/frontend/public/contracts/domain/v1/order.proto
+++ b/frontend/public/contracts/domain/v1/order.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package poc.micro.ordering.domain.v1;
 option csharp_namespace = "Poc.Micro.Ordering.Domain.V1";
-import "contracts/domain/v1/common.proto";
+import "common.proto";
 
 message OrderItem {
   string sku = 1;


### PR DESCRIPTION
## Summary
- correct Dispatcher and Order proto import paths so protobuf.js resolves them correctly

## Testing
- `npm install`
- `npm run build`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32b7195a4832c80474e2d2f71d059