### PR TITLE
Document gRPC-Web proxy usage and fix frontend proto imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ npm run dev
 
 When running locally, ensure a gRPC-Web proxy (e.g. `grpcwebproxy`) forwards requests to the dispatcher on port `8080`.
 
+## gRPC-Web proxy
+
+The `grpcproxy` service bridges browser gRPC-Web requests to the native gRPC
+dispatcher. It listens on `0.0.0.0:8080`, accepts gRPC-Web traffic and
+translates it into standard gRPC calls forwarded to `dispatcher:8080`.
+It uses [`github.com/improbable-eng/grpc-web/go/grpcweb`](https://github.com/improbable-eng/grpc-web)
+to handle the gRPC-Web protocol and
+[`github.com/mwitkow/grpc-proxy/proxy`](https://github.com/mwitkow/grpc-proxy)
+to relay any method without pre-registering them. Before forwarding, the proxy
+removes low-level headers such as `user-agent` and `connection`. The process is
+transparent for clients: no `.proto` regeneration is required—simply point the
+browser to the proxy endpoint.
+

--- a/frontend/public/contracts/api/v1/dispatcher.proto
+++ b/frontend/public/contracts/api/v1/dispatcher.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 package poc.micro.ordering.api.v1;
 option csharp_namespace = "Poc.Micro.Ordering.Api.V1";
-import "contracts/domain/v1/order.proto";
-import "contracts/domain/v1/common.proto";
+import "../domain/v1/order.proto";
+import "../domain/v1/common.proto";
 
 service Dispatcher {
   rpc SubmitOrder(SubmitOrderRequest) returns (SubmitOrderResponse);

--- a/frontend/public/contracts/domain/v1/order.proto
+++ b/frontend/public/contracts/domain/v1/order.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package poc.micro.ordering.domain.v1;
 option csharp_namespace = "Poc.Micro.Ordering.Domain.V1";
-import "contracts/domain/v1/common.proto";
+import "common.proto";
 
 message OrderItem {
   string sku = 1;


### PR DESCRIPTION
## Summary
- document the Go gRPC-Web proxy bridging browser requests to the gRPC backend
- fix frontend .proto import paths so Protobuf.js resolves dependencies without 404s

## Testing
- `npm install`
- `npm run build`
- `go build .` (in grpcproxy)
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32b7195a4832c80474e2d2f71d059