### PR TITLE
fix: load proto dependencies from root

### DIFF
--- a/frontend/src/dispatcherClient.js
+++ b/frontend/src/dispatcherClient.js
@@ -1,6 +1,15 @@
 import protobuf from 'protobufjs';
 
-const rootPromise = protobuf.load('/contracts/api/v1/dispatcher.proto');
+// Ensure protobuf.js resolves contract imports from the repository root
+const root = new protobuf.Root();
+root.resolvePath = (origin, target) => {
+  if (target.startsWith('contracts/')) {
+    return `/${target}`;
+  }
+  return protobuf.util.path.resolve(origin, target);
+};
+
+const rootPromise = root.load('/contracts/api/v1/dispatcher.proto');
 
 function frameRequest(buf) {
   const out = new Uint8Array(5 + buf.length);


### PR DESCRIPTION
## Summary
- ensure protobuf.js resolves proto imports from repository root to prevent 404 errors

## Testing
- `npm run build`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b332ae1498832cb6df0310eeb4619c