### PR TITLE
Ensure orders are persisted within transaction

### DIFF
--- a/src/Services/Data/Ordering.Application/Orders/OrdersAppService.cs
+++ b/src/Services/Data/Ordering.Application/Orders/OrdersAppService.cs
@@ -43,11 +43,10 @@ public sealed class OrdersAppService : IOrdersAppService
             )).ToList()
         );
 
-        await _orders.AddAsync(order, ct);
-
-        await _uow.ExecuteInTransactionAsync(async _ =>
+        await _uow.ExecuteInTransactionAsync(async ctInner =>
         {
-            await _uow.SaveChangesAsync(ct);
+            await _orders.AddAsync(order, ctInner);
+            await _uow.SaveChangesAsync(ctInner);
         }, ct);
 
         return new Uuid { Value = orderId.ToString() };

--- a/tests/Data.Tests/Data.Tests.csproj
+++ b/tests/Data.Tests/Data.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Services/Data/Ordering.Application/Ordering.Application.csproj" />
+    <ProjectReference Include="../../src/Services/Data/Data.Infrastructure/Data.Infrastructure.csproj" />
+    <ProjectReference Include="../../src/BuildingBlocks/Persistence/Persistence.EntityFramework/Persistence.EntityFramework.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/Data.Tests/OrdersAppServiceTests.cs
+++ b/tests/Data.Tests/OrdersAppServiceTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Poc.Micro.Data.Infrastructure;
+using Poc.Micro.Ordering.Application.Orders;
+using Poc.Micro.Ordering.Domain.V1;
+using Poc.Micro.Persistence.EntityFramework;
+using DomainOrder = Poc.Micro.Ordering.Domain.Orders.Order;
+using Xunit;
+
+namespace Data.Tests;
+
+public class OrdersAppServiceTests
+{
+    [Fact]
+    public async Task SavePricedOrderAsync_PersistsOrder()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<OrderDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var db = new OrderDbContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        var repo = new Repository<DomainOrder>(db);
+        var uow = new EfUnitOfWork(db);
+        var svc = new OrdersAppService(repo, uow);
+
+        var orderId = Guid.NewGuid();
+        var dto = new PricedOrder
+        {
+            Order = new Order
+            {
+                OrderId = new Uuid { Value = orderId.ToString() },
+                CustomerId = "c1",
+                Items = { new OrderItem { Sku = "A", Qty = new Quantity { Value = 1 }, UnitPrice = new Money { Amount = 5, Currency = "EUR" } } }
+            },
+            Subtotal = new Money { Amount = 5, Currency = "EUR" },
+            Tax = new Money { Amount = 1, Currency = "EUR" },
+            Total = new Money { Amount = 6, Currency = "EUR" }
+        };
+
+        await svc.SavePricedOrderAsync(dto, CancellationToken.None);
+
+        var saved = await db.Orders.Include(o => o.Items).SingleOrDefaultAsync(o => o.OrderId == orderId);
+        Assert.NotNull(saved);
+        Assert.Single(saved!.Items);
+    }
+}


### PR DESCRIPTION
## Summary
- wrap order save logic in a transaction to ensure records persist
- add unit test verifying that `SavePricedOrderAsync` writes an order to the database

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ef427b6c832c8b159c97e7323999