### PR TITLE
feat(frontend): add order grid and styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,6 +410,9 @@ FodyWeavers.xsd
 # Built Visual Studio Code Extensions
 *.vsix
 
+# Frontend build output
+frontend/dist/
+
 # Windows Installer files from build outputs
 *.cab
 *.msi

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,25 @@
 <template>
-  <OrderForm />
+  <div class="container">
+    <OrderForm @submitted="addOrder" />
+    <OrdersGrid :orders="orders" />
+  </div>
 </template>
 
 <script setup>
+import { ref } from 'vue';
 import OrderForm from './components/OrderForm.vue';
+import OrdersGrid from './components/OrdersGrid.vue';
+
+const orders = ref([]);
+
+function addOrder(order) {
+  orders.value.push(order);
+}
 </script>
+
+<style scoped>
+.container {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+}
+</style>

--- a/frontend/src/components/OrderForm.vue
+++ b/frontend/src/components/OrderForm.vue
@@ -1,25 +1,27 @@
 <template>
-  <form @submit.prevent="send">
-    <div>
+  <form class="order-form" @submit.prevent="send">
+    <div class="form-row">
       <label>Customer ID</label>
       <input v-model="customerId" />
     </div>
-    <div>
+    <div class="form-row">
       <label>SKU</label>
       <input v-model="sku" />
     </div>
-    <div>
+    <div class="form-row">
       <label>Quantity</label>
       <input type="number" v-model.number="qty" />
     </div>
-    <button type="submit">Submit</button>
+    <button class="submit-btn" type="submit">Submit</button>
     <p v-if="jobId">Job ID: {{ jobId }}</p>
   </form>
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, defineEmits } from 'vue';
 import { submitOrder } from '../dispatcherClient';
+
+const emit = defineEmits(['submitted']);
 
 const customerId = ref('');
 const sku = ref('');
@@ -45,8 +47,31 @@ async function send() {
   try {
     const resp = await submitOrder(order);
     jobId.value = resp.jobId?.value || '';
+    emit('submitted', { ...order, jobId: jobId.value });
+    customerId.value = '';
+    sku.value = '';
+    qty.value = 1;
   } catch (err) {
     console.error(err);
   }
 }
 </script>
+
+<style scoped>
+.order-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #f9f9f9;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 400px;
+}
+.form-row {
+  display: flex;
+  flex-direction: column;
+}
+.submit-btn {
+  align-self: flex-start;
+}
+</style>

--- a/frontend/src/components/OrdersGrid.vue
+++ b/frontend/src/components/OrdersGrid.vue
@@ -1,0 +1,48 @@
+<template>
+  <table v-if="orders.length" class="orders-grid">
+    <thead>
+      <tr>
+        <th>Job ID</th>
+        <th>Customer ID</th>
+        <th>SKU</th>
+        <th>Quantity</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="order in orders" :key="order.orderId.value">
+        <td>{{ order.jobId }}</td>
+        <td>{{ order.customerId }}</td>
+        <td>{{ order.items[0].sku }}</td>
+        <td>{{ order.items[0].qty.value }}</td>
+      </tr>
+    </tbody>
+  </table>
+  <p v-else>No orders yet.</p>
+</template>
+
+<script setup>
+import { defineProps } from 'vue';
+
+defineProps({
+  orders: {
+    type: Array,
+    default: () => []
+  }
+});
+</script>
+
+<style scoped>
+.orders-grid {
+  border-collapse: collapse;
+  width: 100%;
+  margin-top: 20px;
+}
+.orders-grid th, .orders-grid td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+.orders-grid th {
+  background-color: #f2f2f2;
+  text-align: left;
+}
+</style>


### PR DESCRIPTION
## Summary
- improve order submission form with basic styling
- display submitted orders in a table grid
- ignore built frontend assets

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4738481cc832cb84ae9866e31380f