### PR TITLE
feat: expose stored orders

### DIFF
--- a/contracts/api/v1/data.proto
+++ b/contracts/api/v1/data.proto
@@ -3,7 +3,13 @@ package poc.micro.ordering.api.v1;
 option csharp_namespace = "Poc.Micro.Ordering.Api.V1";
 import "contracts/domain/v1/order.proto";
 import "contracts/domain/v1/common.proto";
+import "google/protobuf/empty.proto";
 
 service Data {
   rpc SaveOrder(poc.micro.ordering.domain.v1.PricedOrder) returns (poc.micro.ordering.domain.v1.Uuid);
+  rpc ListOrders(google.protobuf.Empty) returns (ListOrdersResponse);
+}
+
+message ListOrdersResponse {
+  repeated poc.micro.ordering.domain.v1.PricedOrder orders = 1;
 }

--- a/contracts/api/v1/dispatcher.proto
+++ b/contracts/api/v1/dispatcher.proto
@@ -3,10 +3,13 @@ package poc.micro.ordering.api.v1;
 option csharp_namespace = "Poc.Micro.Ordering.Api.V1";
 import "contracts/domain/v1/order.proto";
 import "contracts/domain/v1/common.proto";
+import "contracts/api/v1/data.proto";
+import "google/protobuf/empty.proto";
 
 service Dispatcher {
   rpc SubmitOrder(SubmitOrderRequest) returns (SubmitOrderResponse);
   rpc GetStatus(GetStatusRequest) returns (stream JobStatus);
+  rpc ListOrders(google.protobuf.Empty) returns (ListOrdersResponse);
 }
 
 message SubmitOrderRequest {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,15 +6,25 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import OrderForm from './components/OrderForm.vue';
 import OrdersGrid from './components/OrdersGrid.vue';
+import { fetchOrders } from './dispatcherClient';
 
 const orders = ref([]);
 
 function addOrder(order) {
   orders.value.push(order);
 }
+
+onMounted(async () => {
+  try {
+    const res = await fetchOrders();
+    orders.value = res.orders.map(o => ({ ...o.order, jobId: o.order.orderId?.value }));
+  } catch (err) {
+    console.error(err);
+  }
+});
 </script>
 
 <style scoped>

--- a/frontend/src/dispatcherClient.js
+++ b/frontend/src/dispatcherClient.js
@@ -46,3 +46,22 @@ export async function submitOrder(order) {
   const buffer = new Uint8Array(await res.arrayBuffer());
   return SubmitOrderResponse.decode(parseResponse(buffer));
 }
+
+export async function fetchOrders() {
+  const root = await rootPromise;
+  const Empty = root.lookupType('google.protobuf.Empty');
+  const ListOrdersResponse = root.lookupType('poc.micro.ordering.api.v1.ListOrdersResponse');
+  const body = frameRequest(Empty.encode(Empty.create()).finish());
+
+  const res = await fetch('http://localhost:8080/poc.micro.ordering.api.v1.Dispatcher/ListOrders', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/grpc-web+proto',
+      'X-Grpc-Web': '1'
+    },
+    body
+  });
+
+  const buffer = new Uint8Array(await res.arrayBuffer());
+  return ListOrdersResponse.decode(parseResponse(buffer));
+}

--- a/src/Services/Data/Data.Api/DataService.cs
+++ b/src/Services/Data/Data.Api/DataService.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Grpc.Core;
+using Google.Protobuf.WellKnownTypes;
 using Poc.Micro.Ordering.Api.V1;
 using Poc.Micro.Ordering.Application.Orders;
 using Poc.Micro.Ordering.Domain.V1;
@@ -17,4 +18,10 @@ public class DataService : Poc.Micro.Ordering.Api.V1.Data.DataBase
 
     public override Task<Uuid> SaveOrder(PricedOrder request, ServerCallContext context)
         => _app.SavePricedOrderAsync(request, context.CancellationToken);
+
+    public override async Task<ListOrdersResponse> ListOrders(Empty request, ServerCallContext context)
+    {
+        var orders = await _app.ListPricedOrdersAsync(context.CancellationToken);
+        return new ListOrdersResponse { Orders = { orders } };
+    }
 }

--- a/src/Services/Data/Ordering.Application/Orders/IOrdersAppService.cs
+++ b/src/Services/Data/Ordering.Application/Orders/IOrdersAppService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Poc.Micro.Ordering.Domain.V1;
@@ -7,4 +8,5 @@ namespace Poc.Micro.Ordering.Application.Orders;
 public interface IOrdersAppService
 {
     Task<Uuid> SavePricedOrderAsync(PricedOrder dto, CancellationToken ct);
+    Task<List<PricedOrder>> ListPricedOrdersAsync(CancellationToken ct);
 }

--- a/src/Services/Dispatcher/Dispatcher.Api/DispatcherService.cs
+++ b/src/Services/Dispatcher/Dispatcher.Api/DispatcherService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Grpc.Core;
+using Google.Protobuf.WellKnownTypes;
 using Poc.Micro.Ordering.Api.V1;
 using Poc.Micro.Ordering.Domain.V1;
 
@@ -12,11 +13,13 @@ public class DispatcherService : ApiDispatcher.DispatcherBase
 {
     private readonly JobStore _jobs;
     private readonly Logging.LoggingClient _log;
+    private readonly Data.DataClient _data;
 
-    public DispatcherService(JobStore jobs, Logging.LoggingClient log)
+    public DispatcherService(JobStore jobs, Logging.LoggingClient log, Data.DataClient data)
     {
         _jobs = jobs;
         _log = log;
+        _data = data;
     }
 
     public override async Task<SubmitOrderResponse> SubmitOrder(SubmitOrderRequest request, ServerCallContext context)
@@ -57,6 +60,9 @@ public class DispatcherService : ApiDispatcher.DispatcherBase
             await Task.Delay(300, context.CancellationToken);
         }
     }
+
+    public override Task<ListOrdersResponse> ListOrders(Empty request, ServerCallContext context)
+        => _data.ListOrdersAsync(request, cancellationToken: context.CancellationToken);
 
     private static Guid CreateV7() => Guid.CreateVersion7(DateTimeOffset.UtcNow);
 }

--- a/tests/Data.Tests/OrdersAppServiceTests.cs
+++ b/tests/Data.Tests/OrdersAppServiceTests.cs
@@ -51,4 +51,43 @@ public class OrdersAppServiceTests
         Assert.NotNull(saved);
         Assert.Single(saved!.Items);
     }
+
+    [Fact]
+    public async Task ListPricedOrdersAsync_ReturnsSavedOrders()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<OrderDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var db = new OrderDbContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        var repo = new Repository<DomainOrder>(db);
+        var uow = new EfUnitOfWork(db);
+        var svc = new OrdersAppService(repo, uow);
+
+        var orderId = Guid.NewGuid();
+        var dto = new PricedOrder
+        {
+            Order = new Order
+            {
+                OrderId = new Uuid { Value = orderId.ToString() },
+                CustomerId = "c1",
+                Items = { new OrderItem { Sku = "A", Qty = new Quantity { Value = 1 }, UnitPrice = new Money { Amount = 5, Currency = "EUR" } } }
+            },
+            Subtotal = new Money { Amount = 5, Currency = "EUR" },
+            Tax = new Money { Amount = 1, Currency = "EUR" },
+            Total = new Money { Amount = 6, Currency = "EUR" }
+        };
+
+        await svc.SavePricedOrderAsync(dto, CancellationToken.None);
+
+        var list = await svc.ListPricedOrdersAsync(CancellationToken.None);
+
+        Assert.Single(list);
+        Assert.Equal(orderId.ToString(), list[0].Order.OrderId.Value);
+    }
 }


### PR DESCRIPTION
## Summary
- allow data service to list stored orders and expose list through dispatcher
- fetch persisted orders on app load so old orders are visible in UI
- cover listing in application service tests

## Testing
- `DOTNET_ROLL_FORWARD=major dotnet test` *(fails: A compatible .NET SDK was not found; requires 9.0.304)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b552630a40832ca1c7e48f2dc5ec58